### PR TITLE
Fix Free space not being reported correctly

### DIFF
--- a/src/static/static/yi-hack/script/clean_records.sh
+++ b/src/static/static/yi-hack/script/clean_records.sh
@@ -20,7 +20,7 @@ USED_SPACE_LIMIT=$((100-$1))
 echo "$USED_SPACE_LIMIT"
 
 cd /tmp/sd/record
-USED_SPACE=`df /tmp/sd/ | grep mmc | awk '{print $5}' | tr -d '%'`
+USED_SPACE=`df | grep -m1 '/tmp/sd' |  grep mmc | awk '{print $5}' | tr -d '%'`
 
 if [ -z "$USED_SPACE" ]; then
     exit
@@ -35,7 +35,7 @@ do
     else
         exit
     fi
-    USED_SPACE=`df /tmp/sd/ | grep mmc | awk '{print $5}' | tr -d '%'`
+    USED_SPACE=`df | grep -m1 '/tmp/sd' |  grep mmc | awk '{print $5}' | tr -d '%'`
 done
 
 echo "Done!"

--- a/src/static/static/yi-hack/script/mqtt_advertise/mqtt_adv_telemetry.sh
+++ b/src/static/static/yi-hack/script/mqtt_advertise/mqtt_adv_telemetry.sh
@@ -22,7 +22,7 @@ UPTIME=$(cat /proc/uptime | cut -d ' ' -f1)
 LOAD_AVG=$(cat /proc/loadavg | cut -d ' ' -f1-3)
 TOTAL_MEMORY=$(free -k | awk 'NR==2{print $2}')
 FREE_MEMORY=$(free -k | awk 'NR==2{print $4+$6+$7}')
-FREE_SD=$(df /tmp/sd/ | grep mmc | awk '{print $5}' | tr -d '%')
+FREE_SD=$(df | grep -m1 '/tmp/sd' |  grep mmc | awk '{print $5}' | tr -d '%')
 WLAN_STRENGTH=$(cat /proc/net/wireless | awk 'END { print $3 }' | sed 's/\.$//')
 
 # MQTT configuration

--- a/src/www/httpd/cgi-bin/fw_upgrade.sh
+++ b/src/www/httpd/cgi-bin/fw_upgrade.sh
@@ -26,7 +26,7 @@ if [ "$VAL" == "info" ] ; then
 
 elif [ "$VAL" == "upgrade" ] ; then
 
-    FREE_SD=$(df /tmp/sd/ | grep mmc | awk '{print $4}')
+    FREE_SD=$(df | grep -m1 '/tmp/sd' | grep mmc | awk '{print $4}')
     if [ -z "$FREE_SD" ]; then
         printf "Content-type: text/html\r\n\r\n"
         printf "No SD detected."

--- a/src/www/httpd/cgi-bin/status.json
+++ b/src/www/httpd/cgi-bin/status.json
@@ -22,7 +22,7 @@ UPTIME=$(cat /proc/uptime | cut -d ' ' -f1)
 LOAD_AVG=$(cat /proc/loadavg | cut -d ' ' -f1-3)
 TOTAL_MEMORY=$(free -k | awk 'NR==2{print $2}')
 FREE_MEMORY=$(free -k | awk 'NR==2{print $4+$6+$7}')
-FREE_SD=$(df /tmp/sd/ | grep mmc | awk '{print $5}' | tr -d '%')
+FREE_SD=$(df | grep -m1 '/tmp/sd' |  grep mmc | awk '{print $5}' | tr -d '%')
 if [ -z "$FREE_SD" ]; then
     FREE_SD="N/A"
 else


### PR DESCRIPTION
### Free space was always being reported as 100%

This problem didn't allow 'clean_records.sh' to do it's job.

`df /tmp/sd` result is (on y21ga):

![2021-05-26_10-22](https://user-images.githubusercontent.com/182139/119636245-5a5f1d80-be0c-11eb-91d4-6a5ff8917b75.png)

I don't have any other model to test this on.

