### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+ARG VARIANT="debian-10"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+RUN export DEBIAN_FRONTEND=noninteractive               && \
+    apt-get update                                      && \
+    apt-get -y install --no-install-recommends             \
+      git wget unzip build-essential libtool bison         \
+      bisonc++ libbison-dev autoconf autotools-dev         \
+      automake libssl-dev zlibc zlib1g-dev libzzip-dev     \
+      flex libfl-dev yui-compressor closure-compiler       \
+      optipng jpegoptim libtidy5deb1 node-less sassc       \
+      sass-spec libhtml-tidy-perl libxml2-utils rsync
+
+# Download toolchain
+RUN git clone https://github.com/lindenis-org/lindenis-v536-prebuilt                                              && \
+    mkdir -p /opt/yi/toolchain-sunxi-musl                                                                         && \
+    cp -r lindenis-v536-prebuilt/gcc/linux-x86/arm/toolchain-sunxi-musl/toolchain /opt/yi/toolchain-sunxi-musl/
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "yi-hack devcontainer",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { "VARIANT": "debian-10" }
+	},
+
+	"remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -180,11 +180,13 @@ data:
 
 If you want to build your own firmware, clone this git and compile using a linux machine. Quick explanation:
 
-1. Download and install the SDK as described [here](https://github.com/roleoroleo/yi-hack-Allwinner-v2/wiki/Build-your-own-firmware
+1. Download and install the SDK as described [here](https://github.com/roleoroleo/yi-hack-Allwinner-v2/wiki/Build-your-own-firmware)
 2. Clone this git: `git clone https://github.com/roleoroleo/yi-hack-Allwinner-v2`
 3. Init modules: `git submodule update --init`
 4. Compile: `./scripts/compile.sh`
 5. Pack the firmware: `./scripts/pack_fw.all.sh`
+
+Instead of installing the SDK on your host machine, there's also the option to use a [`devcontainer`](https://code.visualstudio.com/docs/remote/containers) from within [Visual Studio Code](https://code.visualstudio.com/). Please ensure you have the [`Remote - Containers`](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension installed for this to work.
 
 
 ## Unbricking


### PR DESCRIPTION
This PR adds a simple [devcontainer](https://code.visualstudio.com/docs/remote/containers) environment for easier local development.

After opening the project in [Visual Studio Code](https://code.visualstudio.com/) and installing the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, the project can be reopened inside the container by Pressing `F1` and typing in `Reopen in Container`. Afterwards a terminal session can be opened by selecting `Terminal > New Terminal`. From here, the code can be compiled using `sudo ./scripts/compile.sh`.