### PR TITLE
Add ipc-notify program for custom scripting

### DIFF
--- a/src/ipc_cmd/compile.ipc_cmd
+++ b/src/ipc_cmd/compile.ipc_cmd
@@ -29,5 +29,6 @@ mkdir -p ../_install/bin || exit 1
 cp ./ipc_cmd ../_install/bin || exit 1
 cp ./ipc_read ../_install/bin || exit 1
 cp ./ipc_multiplexer ../_install/bin || exit 1
+cp ./ipc_notify ../_install/bin || exit 1
 
 ${STRIP} ../_install/bin/* || exit 1

--- a/src/ipc_cmd/ipc_cmd/Makefile
+++ b/src/ipc_cmd/ipc_cmd/Makefile
@@ -1,9 +1,10 @@
 OBJECTS_C = ipc_cmd.o
 OBJECTS_R = ipc_read.o
 OBJECTS_M = ipc_multiplexer.o
+OBJECTS_N = ipc_notify.o
 #LIBS = -lpthread -lrt
 
-all: ipc_cmd ipc_read ipc_multiplexer
+all: ipc_cmd ipc_read ipc_multiplexer ipc_notify
 
 ipc_cmd.o: ipc_cmd.c $(HEADERS)
 	$(CC) -c $< -fPIC -Os -o $@
@@ -26,12 +27,18 @@ ipc_multiplexer: $(OBJECTS_M)
 	$(CC) $(OBJECTS_M) $(LIBS) -fPIC -Os -o $@
 	$(STRIP) $@
 
+ipc_notify: $(OBJECTS_N)
+	$(CC) $(OBJECTS_N) $(LIBS) -fPIC -Os -o $@
+	$(STRIP) $@
+
 .PHONY: clean
 
 clean:
 	rm -f ipc_cmd
 	rm -f ipc_read
 	rm -f ipc_multiplexer
+	rm -f ipc_notify
 	rm -f $(OBJECTS_C)
 	rm -f $(OBJECTS_R)
 	rm -f $(OBJECTS_M)
+	rm -f $(OBJECTS_N)

--- a/src/ipc_cmd/ipc_cmd/ipc_notify.c
+++ b/src/ipc_cmd/ipc_cmd/ipc_notify.c
@@ -1,0 +1,208 @@
+#include "ipc_notify.h"
+
+static mqd_t ipc_mq;
+int queue_number;
+char command_buffer[COMMAND_MAX_SIZE + 1];
+int debug;
+
+static int open_queue();
+static int parse_message(char *msg, char* cmd, ssize_t len);
+
+int ipc_init()
+{
+    int ret;
+
+    ret = open_queue();
+    if(ret != 0)
+        return -1;
+
+    ret = clear_queue();
+    if(ret != 0)
+        return -2;
+
+    return 0;
+}
+
+void ipc_stop()
+{
+    if(ipc_mq > 0)
+        mq_close(ipc_mq);
+}
+
+static int open_queue()
+{
+    char queue_name[256];
+
+    sprintf(queue_name, "%s_%d", IPC_QUEUE_NAME, queue_number);
+    ipc_mq = mq_open(queue_name, O_RDONLY);
+    if(ipc_mq == -1) {
+        fprintf(stderr, "Can't open mqueue %s. Error: %s\n", queue_name, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+static int clear_queue()
+{
+    struct mq_attr attr;
+    char buffer[IPC_MESSAGE_MAX_SIZE + 1];
+
+    if (mq_getattr(ipc_mq, &attr) == -1) {
+        fprintf(stderr, "Can't get queue attributes\n");
+        return -1;
+    }
+
+    while (attr.mq_curmsgs > 0) {
+        if (debug) fprintf(stderr, "Clear message in queue...");
+        mq_receive(ipc_mq, buffer, IPC_MESSAGE_MAX_SIZE, NULL);
+        if (debug) fprintf(stderr, " done.\n");
+        if (mq_getattr(ipc_mq, &attr) == -1) {
+            fprintf(stderr, "Can't get queue attributes\n");
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int parse_message(char *msg, char *cmd, ssize_t len)
+{
+    int i;
+
+    if (debug) fprintf(stderr, "Parsing message\n");
+
+    for(i=0; i<len; i++)
+        if (debug) fprintf(stderr, "%02x ", msg[i]);
+    if (debug) fprintf(stderr, "\n");
+
+    msg[len] = '\0';
+
+    size_t buffer_size = sizeof(command_buffer);
+    int bytes_written = snprintf(command_buffer, buffer_size, "%s \"%s\"", cmd, msg);
+    if (bytes_written >= buffer_size) {
+        return E2BIG;
+    }
+
+    if (debug) fprintf(stderr, "Executing \"%s\"\n", command_buffer);
+
+    return system(command_buffer);
+}
+
+void print_usage(char *progname)
+{
+    fprintf(stderr, "\nUsage: %s -n NUMBER -c COMMAND [-d]\n\n", progname);
+    fprintf(stderr, "\t-n NUMBER, --number NUMBER\n");
+    fprintf(stderr, "\t\tnumber of the queue (1 to 9)\n");
+    fprintf(stderr, "\t-c COMMAND, --command COMMAND\n");
+    fprintf(stderr, "\t\tthe command to execute\n");
+    fprintf(stderr, "\t-d,     --debug\n");
+    fprintf(stderr, "\t\tenable debug\n");
+    fprintf(stderr, "\t-h,     --help\n");
+    fprintf(stderr, "\t\tprint this help\n");
+}
+
+void main(int argc, char ** argv)
+{
+    int ret, c;
+    int errno;
+    char *endptr;
+    char *command = 0;
+
+    ssize_t bytes_read;
+    char buffer[IPC_MESSAGE_MAX_SIZE + 1];
+
+    queue_number = -1;
+    debug = 0;
+
+    while (1) {
+        static struct option long_options[] =
+        {
+            {"number",  required_argument, 0, 'n'},
+            {"command",  required_argument, 0, 'c'},
+            {"debug",  no_argument, 0, 'd'},
+            {"help",  no_argument, 0, 'h'},
+            {0, 0, 0, 0}
+        };
+        /* getopt_long stores the option index here. */
+        int option_index = 0;
+
+        c = getopt_long (argc, argv, "n:c:dh",
+                         long_options, &option_index);
+
+        /* Detect the end of the options. */
+        if (c == -1)
+            break;
+
+        switch (c) {
+        case 'n':
+            errno = 0;    /* To distinguish success/failure after call */
+            queue_number = strtol(optarg, &endptr, 10);
+
+            /* Check for various possible errors */
+            if ((errno == ERANGE && (queue_number == LONG_MAX || queue_number == LONG_MIN)) || (errno != 0 && queue_number == 0)) {
+                print_usage(argv[0]);
+                exit(EXIT_FAILURE);
+            }
+            if (queue_number <= 0 || queue_number >= 10) {
+                print_usage(argv[0]);
+                exit(EXIT_FAILURE);
+            }
+            if (endptr == optarg) {
+                print_usage(argv[0]);
+                exit(EXIT_FAILURE);
+            }
+            break;
+
+        case 'c':
+            command = optarg;
+            break;
+
+        case 'd':
+            fprintf(stderr, "debug on\n");
+            debug = 1;
+            break;
+
+        case 'h':
+            print_usage(argv[0]);
+            exit(EXIT_SUCCESS);
+            break;
+
+        case '?':
+            /* getopt_long already printed an error message. */
+            break;
+
+        default:
+            print_usage(argv[0]);
+            exit(EXIT_SUCCESS);
+        }
+    }
+
+    if (queue_number == -1) {
+        print_usage(argv[0]);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = ipc_init();
+    if(ret != 0)
+        exit(EXIT_FAILURE);
+
+    while(1) {
+        bytes_read = mq_receive(ipc_mq, buffer, IPC_MESSAGE_MAX_SIZE, NULL);
+
+        if (debug) fprintf(stderr, "IPC message. Len: %d. Status: %s!\n", bytes_read, strerror(errno));
+
+        if(bytes_read >= 0) {
+            int status = parse_message(buffer, command, bytes_read);
+            if (status == E2BIG) {
+                fprintf(stderr, "The specified command is too long. Please shorten it.\n");
+                break;
+            } else if (debug && status != 0) {
+                fprintf(stderr, "Command returned error code %d.\n", status);
+            }
+        }
+
+        usleep(500 * 1000);
+    }
+
+    ipc_stop();
+}

--- a/src/ipc_cmd/ipc_cmd/ipc_notify.h
+++ b/src/ipc_cmd/ipc_cmd/ipc_notify.h
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <limits.h>
+#include <time.h>
+#include <getopt.h>
+#include <mqueue.h>
+#include <pthread.h>
+
+#define IPC_QUEUE_NAME          "/ipc_dispatch"
+#define IPC_MESSAGE_MAX_SIZE    512
+#define COMMAND_MAX_SIZE        512
+
+int ipc_init();
+void ipc_stop();
+static int open_queue();
+static int clear_queue();
+static int parse_message(char *msg, char *cmd, ssize_t len);
+void print_usage(char *progname);


### PR DESCRIPTION
This PR adds a slightly modified version of [`ipc_read`](https://github.com/roleoroleo/yi-hack-Allwinner-v2/blob/master/src/ipc_cmd/ipc_cmd/ipc_read.c) enabling functionality similar to hooks. The program accepts an additional `--command` parameter which is expected to be a path to a script/program. Once a message arrives the specified program is called with the message as the first parameter.

Autostarting this program on boot enables the user to execute custom scripts/programs on any event. 

### Example
```
ipc_notify -n 2 -c "/bin/ash /tmp/sd/yi-hack/script/echo_event.sh"
```

`echo_event.sh`
```shell
#!/bin/ash

echo "${1}"
```