### PR TITLE
Imprv swap

### DIFF
--- a/src/static/static/yi-hack/script/system.sh
+++ b/src/static/static/yi-hack/script/system.sh
@@ -77,6 +77,7 @@ hostname -F $YI_HACK_PREFIX/etc/hostname
 if [[ $(get_config SWAP_FILE) == "yes" ]] ; then
     SD_PRESENT=$(mount | grep mmc | grep "/tmp/sd " | grep -c ^)
     if [[ $SD_PRESENT -eq 1 ]]; then
+        sysctl -w vm.swappiness=15
         if [[ -f /tmp/sd/swapfile ]]; then
             swapon /tmp/sd/swapfile
         else


### PR DESCRIPTION
By default swappiness is set at 60% which is a lot. Lower it to 15% Allow the system to only swap when there is less than 9137 KB free. It will preserve the sdcard and maybe improve speed when swap is enabled (use max ram)