### PR TITLE
Allow set preset and fix go to preset

### DIFF
--- a/src/static/static/yi-hack/script/mqtt_advertise/mqtt_adv_homeassistant.sh
+++ b/src/static/static/yi-hack/script/mqtt_advertise/mqtt_adv_homeassistant.sh
@@ -284,6 +284,9 @@ MQTT_RETAIN_MOTION_IMAGE=$(get_config MQTT_RETAIN_MOTION_IMAGE)
 # fi
 CONTENT='{"availability_topic":"'$MQTT_PREFIX'/'$TOPIC_BIRTH_WILL'","payload_available":"'$BIRTH_MSG'","payload_not_available":"'$WILL_MSG'","device":'$DEVICE_DETAILS', "qos": "'$MQTT_QOS'", '$RETAIN' "topic":"'$MQTT_PREFIX'/'$TOPIC_MOTION_IMAGE'","name":"'$UNIQUE_NAME'","unique_id":"'$UNIQUE_ID'", "platform": "mqtt"}'
 mqtt_publish
+# PTZ preset
+hass_setup_number "PTZ_PRESET" "Camera Preset" "numeric" $MQTT_ADV_CAMERA_SETTING_TOPIC 0 7 1 "box" ""
+mqtt_publish
 if [ "$MQTT_ADV_CAMERA_SETTING_ENABLE" == "yes" ]; then
     if [ "$MQTT_ADV_CAMERA_SETTING_RETAIN" == "1" ]; then
         RETAIN='"retain":true, '

--- a/src/static/static/yi-hack/script/mqtt_advertise/mqtt_set_config.sh
+++ b/src/static/static/yi-hack/script/mqtt_advertise/mqtt_set_config.sh
@@ -75,6 +75,9 @@ $YI_HACK_PREFIX/bin/mosquitto_sub -v -h $HOST -t $TOPIC | while read -r SUBSCRIB
         rotate)
             IPC_OPT="-r"
         ;;
+        ptz_preset)
+            IPC_OPT="-p"
+        ;;
     esac
     if [ "$VAL" == "no" ] || [ "$VAL" == "off" ] ; then
         VAL="off"

--- a/src/www/httpd/cgi-bin/preset.sh
+++ b/src/www/httpd/cgi-bin/preset.sh
@@ -4,11 +4,16 @@ YI_HACK_PREFIX="/tmp/sd/yi-hack"
 
 . $YI_HACK_PREFIX/www/cgi-bin/validate.sh
 
-if ! $(validateQueryString $QUERY_STRING); then
+return_error() {
     printf "Content-type: application/json\r\n\r\n"
     printf "{\n"
-    printf "\"%s\":\"%s\"\\n" "error" "true"
+    printf "\"%s\":\"%s\",\\n" "error" "true"
+    printf "\"%s\":\"%s\"\\n" "message" "$@"
     printf "}"
+}
+
+if ! $(validateQueryString $QUERY_STRING); then
+    return_error "Invalid query"
     exit
 fi
 
@@ -29,29 +34,16 @@ do
     fi
 done
 
-if [ $ACTION != "go_preset" ] ; then
-    printf "Content-type: application/json\r\n\r\n"
-    printf "{\n"
-    printf "\"%s\":\"%s\"\\n" "error" "true"
-    printf "}"
+if [ $ACTION == "go_preset" ] ; then
+    if [ $NUM -lt 0 ] || [ $NUM -gt 7 ] ; then
+        return_error "Preset number out of range"
+        exit
+    fi
+    ipc_cmd -p $NUM
+else
+    return_error "Invalid action received"
     exit
 fi
-if [ $NUM -lt 0 ] ; then
-    printf "Content-type: application/json\r\n\r\n"
-    printf "{\n"
-    printf "\"%s\":\"%s\"\\n" "error" "true"
-    printf "}"
-    exit
-fi
-if [ $NUM -gt 7 ] ; then
-    printf "Content-type: application/json\r\n\r\n"
-    printf "{\n"
-    printf "\"%s\":\"%s\"\\n" "error" "true"
-    printf "}"
-    exit
-fi
-
-ipc_cmd -p $NUM
 
 printf "Content-type: application/json\r\n\r\n"
 printf "{\n"

--- a/src/www/httpd/cgi-bin/preset.sh
+++ b/src/www/httpd/cgi-bin/preset.sh
@@ -40,6 +40,9 @@ if [ $ACTION == "go_preset" ] ; then
         exit
     fi
     ipc_cmd -p $NUM
+elif [ $ACTION == "set_preset" ] || [ "$REQUEST_METHOD" == "POST" ]; then
+    # set preset
+    ipc_cmd -P
 else
     return_error "Invalid action received"
     exit

--- a/src/www/httpd/htdocs/js/modules/ptz.js
+++ b/src/www/httpd/htdocs/js/modules/ptz.js
@@ -47,9 +47,10 @@ APP.ptz = (function($) {
 
     function gotoPreset(button, select) {
         $(button).attr("disabled", true);
+        preset_num = $(select + " option:selected").text();
         $.ajax({
             type: "GET",
-            url: 'cgi-bin/preset.sh?num=' + $(select + " option:selected").text(),
+            url: 'cgi-bin/preset.sh?action=go_preset&num=' + preset_num,
             dataType: "json",
             error: function(response) {
                 console.log('error', response);

--- a/src/www/httpd/htdocs/js/modules/ptz.js
+++ b/src/www/httpd/htdocs/js/modules/ptz.js
@@ -76,18 +76,16 @@ APP.ptz = (function($) {
             url: 'cgi-bin/status.json',
             dataType: "json",
             success: function(data) {
-                for (let key in data) {
-                    if (key == "model_suffix") {
-                        if ((data[key] == "r30gb") || (data[key] == "r35gb") || (data[key] == "r40ga") || (data[key] == "h51ga") || (data[key] == "h52ga") || (data[key] == "h60ga") || (data[key] == "q321br_lsx") || (data[key] == "qg311r") || (data[key] == "b091qp")) {
-                            $('#ptz_description').show();
-                            $('#ptz_available').hide();
-                            $('#ptz_main').show();
-                        } else {
-                            $('#ptz_description').hide();
-                            $('#ptz_available').show();
-                            $('#ptz_main').hide();
-                        }
-                    }
+                ptz_enabled = ["r30gb", "r35gb", "r40ga", "h51ga", "h52ga", "h60ga", "q321br_lsx", "qg311r", "b091qp"];
+                this_model = data.model_suffix ?? "unknown";
+                if (ptz_enabled.includes(this_model)) {
+                    $('#ptz_description').show();
+                    $('#ptz_available').hide();
+                    $('#ptz_main').show();
+                } else {
+                    $('#ptz_description').hide();
+                    $('#ptz_available').show();
+                    $('#ptz_main').hide();
                 }
             },
             error: function(response) {

--- a/src/www/httpd/htdocs/js/modules/ptz.js
+++ b/src/www/httpd/htdocs/js/modules/ptz.js
@@ -24,9 +24,9 @@ APP.ptz = (function($) {
         $(document).on("click", '#button-goto', function(e) {
             gotoPreset('#button-goto', '#select-goto');
         });
-        $(document).on("click", '#button-set', function(e)){
-            setPreset();
-        }
+        $(document).on("click", '#button-set', function(e) {
+            setPreset('#button-set');
+        });
     }
 
     function move(button, dir) {
@@ -62,7 +62,7 @@ APP.ptz = (function($) {
         });
     }
 
-    function setPreset() {
+    function setPreset(button) {
         $(button).attr("disabled", true);
         $.ajax({
             type: "POST",
@@ -97,7 +97,7 @@ APP.ptz = (function($) {
             dataType: "json",
             success: function(data) {
                 ptz_enabled = ["r30gb", "r35gb", "r40ga", "h51ga", "h52ga", "h60ga", "q321br_lsx", "qg311r", "b091qp"];
-                this_model = data.model_suffix ?? "unknown";
+                this_model = data["model_suffix"] || "unknown";
                 if (ptz_enabled.includes(this_model)) {
                     $('#ptz_description').show();
                     $('#ptz_available').hide();

--- a/src/www/httpd/htdocs/js/modules/ptz.js
+++ b/src/www/httpd/htdocs/js/modules/ptz.js
@@ -24,6 +24,9 @@ APP.ptz = (function($) {
         $(document).on("click", '#button-goto', function(e) {
             gotoPreset('#button-goto', '#select-goto');
         });
+        $(document).on("click", '#button-set', function(e)){
+            setPreset();
+        }
     }
 
     function move(button, dir) {
@@ -47,6 +50,22 @@ APP.ptz = (function($) {
         $.ajax({
             type: "GET",
             url: 'cgi-bin/preset.sh?num=' + $(select + " option:selected").text(),
+            dataType: "json",
+            error: function(response) {
+                console.log('error', response);
+                $(button).attr("disabled", false);
+            },
+            success: function(data) {
+                $(button).attr("disabled", false);
+            }
+        });
+    }
+
+    function setPreset() {
+        $(button).attr("disabled", true);
+        $.ajax({
+            type: "POST",
+            url: 'cgi-bin/preset.sh',
             dataType: "json",
             error: function(response) {
                 console.log('error', response);

--- a/src/www/httpd/htdocs/js/modules/ptz.js
+++ b/src/www/httpd/htdocs/js/modules/ptz.js
@@ -100,11 +100,11 @@ APP.ptz = (function($) {
                 this_model = data["model_suffix"] || "unknown";
                 if (ptz_enabled.includes(this_model)) {
                     $('#ptz_description').show();
-                    $('#ptz_available').hide();
+                    $('#ptz_unavailable').hide();
                     $('#ptz_main').show();
                 } else {
                     $('#ptz_description').hide();
-                    $('#ptz_available').show();
+                    $('#ptz_unavailable').show();
                     $('#ptz_main').hide();
                 }
             },

--- a/src/www/httpd/htdocs/pages/ptz.html
+++ b/src/www/httpd/htdocs/pages/ptz.html
@@ -58,6 +58,9 @@
                     <td>
                         <input class="button-primary" type="button" id="button-goto" value="Goto Preset"/>
                     </td>
+                    <td>
+                        <input class="button-primary" type="button" id="button-set" value="Set Preset"/>
+                    </td>
                 </tr>
                 </tbody>
             </table>

--- a/src/www/httpd/htdocs/pages/ptz.html
+++ b/src/www/httpd/htdocs/pages/ptz.html
@@ -7,7 +7,7 @@
                 In this page you can move your cam.
             </p>
         </div>
-        <div id="ptz_available" class="row" style="display: none;">
+        <div id="ptz_unavailable" class="row" style="display: none;">
             <p>
                 PTZ functions are not available for this camera model.
             </p>


### PR DESCRIPTION
Since the `set_preset` function is currently implemented in `ipc_cmd`, I'm adding it to the Web-UI.

- Fix Web-UI "Goto Preset" not working
- Add Web-UI "Set Preset" button + API `POST /preset.sh`
- Add Home Assistant (MQTT) Camera Preset (not persistent)