### PR TITLE
Add "sleep 1" before rmm run

### DIFF
--- a/src/static/static/yi-hack/script/system.sh
+++ b/src/static/static/yi-hack/script/system.sh
@@ -199,6 +199,7 @@ else
         fi
         cd /home/app
         set_tz_offset -c osd -o off
+        sleep 1
         LD_LIBRARY_PATH="/tmp/sd/yi-hack/lib:/lib:/usr/lib:/home/lib:/home/qigan/lib:/home/app/locallib:/tmp/sd:/tmp/sd/gdb" ./rmm &
         sleep 6
         dd if=/tmp/audio_fifo of=/dev/null bs=1 count=8192


### PR DESCRIPTION
Without this wait, the rmm process fails to start on y291ga with the "Disabled cloud" option enabled. Fixes #670.

-----------------

This feels more like a workaround rather than a fix though.
For some reasons, rmm fails to start if started without the wait.

Here you can find the output of rmm when started manually after the boot (after having disabled the WD's reboot) and the failed one when starting it within `system.sh` (without the wait).

[rmm_fail.txt](https://github.com/roleoroleo/yi-hack-Allwinner-v2/files/12233338/rmm_fail.txt)
[rmm_success.txt](https://github.com/roleoroleo/yi-hack-Allwinner-v2/files/12233339/rmm_success.txt)


I do not see anything obvious missing (for example, all the mounts are up), however `ps` shows that two `system.sh` are running (captured just before the `./rmm` command, without the wait):

```
 PID USER       VSZ STAT COMMAND
    1 root       980 S    /sbin/init
    2 root         0 SW   [kthreadd]
    3 root         0 SW   [ksoftirqd/0]
    4 root         0 SW   [kworker/0:0]
    5 root         0 SW<  [kworker/0:0H]
    6 root         0 SW   [kworker/u2:0]
    7 root         0 SW   [rcu_preempt]
    8 root         0 SW   [rcu_sched]
    9 root         0 SW   [rcu_bh]
   10 root         0 SW<  [lru-add-drain]
   11 root         0 SW   [kdevtmpfs]
   12 root         0 SW   [kworker/u2:1]
  211 root         0 SW   [oom_reaper]
  212 root         0 SW<  [writeback]
  214 root         0 SW   [kcompactd0]
  215 root         0 SW<  [crypto]
  216 root         0 SW<  [bioset]
  218 root         0 SW<  [kblockd]
  259 root         0 SW   [sys_user]
  266 root         0 SW   [kworker/0:1]
  267 root         0 SW<  [cfg80211]
  273 root         0 SW<  [watchdogd]
  288 root         0 SW<  [spi0]
  298 root         0 SW   [kswapd0]
  382 root         0 SW<  [bioset]
  387 root         0 SW<  [bioset]
  392 root         0 SW<  [bioset]
  397 root         0 SW<  [bioset]
  402 root         0 SW<  [bioset]
  407 root         0 SW<  [bioset]
  412 root         0 SW<  [bioset]
  417 root         0 SW<  [bioset]
  422 root         0 SW<  [bioset]
  450 root         0 SW   [irq/302-sunxi-m]
  452 root         0 SW   [irq/166-sdc0 cd]
  453 root         0 SW   [irq/303-sunxi-m]
  454 root         0 SW   [kworker/0:2]
  458 root         0 SW   [kworker/0:3]
  511 root         0 SW<  [bioset]
  512 root         0 SW   [mmcqd/0]
  531 root         0 SW<  [kworker/0:1H]
  544 root         0 SWN  [jffs2_gcd_mtd4]
  583 root       980 S    /usr/sbin/telnetd
  594 root         0 SW<  [phy0-atbm_wq]
  595 root         0 SW   [phy0-usb_atbm_b]
  644 root       904 S    ./dispatch
  647 root       992 S    sh /tmp/sd/yi-hack/script/system.sh
 1212 root         0 Z    [init]
 1240 root       992 S    sh /tmp/sd/yi-hack/script/system.sh
 1266 root       980 R    ps
```

Is it expected?