### PR TITLE
y211ga: prevent running lower_half_init.sh twice

### DIFF
--- a/sysroot/y211ga/lower_half_init.sh
+++ b/sysroot/y211ga/lower_half_init.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# protect against running this script twice and starting up a bunch of duplicate processes
+if [ -f /tmp/init_started ]; then
+    exit
+fi
+
+touch /tmp/init_started
+
 HOMEVER=$(cat /home/homever)
 HV=${HOMEVER:0:2}
 


### PR DESCRIPTION
Fixes an issue I came across where two of pretty much every yi-hack service was running, causing all sorts of issues. I'm not sure why this was happening, but `lower_half_init.sh` was consistently being ran twice on boot, about 4 seconds apart. Using firmware `9.0.36.03_202109231441`.

Would a guard like this make sense to include in all the `lower_half_init.sh` scripts? I don't see it doing any harm, my biggest question is does `/tmp` start fresh on all cameras like it does on my `y211ga`?