### PR TITLE
CVE-2023-48795 - Update dropbear to 2024.86

### DIFF
--- a/src/dropbear/config.dropbear
+++ b/src/dropbear/config.dropbear
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="2022.83"
+VERSION="2024.86"
 MAIN_URL=https://github.com/mkj/dropbear/archive/refs/tags/DROPBEAR_${VERSION}.tar.gz
 PACKAGE="DROPBEAR_${VERSION}"
 ARCHIVE="${PACKAGE}.tar.gz"


### PR DESCRIPTION
Summary of issue:

> Supports following ChaCha20-Poly1305 Client to Server algorithm : chacha20-poly1305@openssh.com
> Supports following ChaCha20-Poly1305 Server to Client algorithm : chacha20-poly1305@openssh.com

Suggested fix:
Update dropbear to 2024.86 to fix CVE-2023-48795

Further info: https://terrapin-attack.com/patches.html

Compiled and tested on b091qp working well, no issues found.


