### PR TITLE
Fix build system: devcontainer deps, gitignore and onvif init script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ INIT_SUBMODULES.md
 src/h264grabber/h264grabber/h264grabber
 src/ipc_cmd/ipc_cmd/ipc_cmd
 src/snapshot/snapshot/imggrabber
+
+# Downloaded/extracted dependency sources (not submodules)
+src/libwolf_*/
+
+# Artifact created by pack_fw.sh
+scripts/yi-hack-Allwinner-v2/

--- a/src/onvif_simple_server/init.onvif_simple_server
+++ b/src/onvif_simple_server/init.onvif_simple_server
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 cd $SCRIPT_DIR
 
@@ -17,34 +19,37 @@ if [ ! -L libtomcrypt ]; then
 fi
 
 MBEDTLS_VERSION=v3.6.5
+MBEDTLS_DIR=mbedtls-3.6.5
 if [ ! -f "${MBEDTLS_VERSION}.tar.gz" ]; then
     wget https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/${MBEDTLS_VERSION}.tar.gz
 fi
-tar zxvf ./v3.4.0.tar.gz
+tar zxf ./${MBEDTLS_VERSION}.tar.gz
 if [ ! -L mbedtls ]; then
-    ln -s mbedtls-3.4.0 mbedtls
+    ln -s ${MBEDTLS_DIR} mbedtls
     cd onvif_simple_server/extras
-    ln -s ../../mbedtls-3.4.0 mbedtls
+    ln -s ../../${MBEDTLS_DIR} mbedtls
     cd ../..
 fi
 cp -f mbedtls_config.h mbedtls/include/mbedtls/
 
 WOLFSSL_VERSION=v5.8.2-stable
+WOLFSSL_DIR=wolfssl-5.8.2-stable
 if [ ! -f "${WOLFSSL_VERSION}.tar.gz" ]; then
     wget https://github.com/wolfSSL/wolfssl/archive/refs/tags/${WOLFSSL_VERSION}.tar.gz
 fi
-tar zxvf ./${WOLFSSL_VERSION}.tar.gz
+tar zxf ./${WOLFSSL_VERSION}.tar.gz
 if [ ! -L wolfssl ]; then
-    ln -s ${WOLFSSL_VERSION} wolfssl
+    ln -s ${WOLFSSL_DIR} wolfssl
     cd onvif_simple_server/extras
-    ln -s ../../${WOLFSSL_VERSION} wolfssl
+    ln -s ../../${WOLFSSL_DIR} wolfssl
     cd ../..
 fi
 
 if [ ! -f zlib-1.3.1.tar.gz ]; then
-    wget https://www.zlib.net/zlib-1.3.1.tar.gz
+    wget https://www.zlib.net/zlib-1.3.1.tar.gz || \
+    wget https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
 fi
-tar zxvf ./zlib-1.3.1.tar.gz
+tar zxf ./zlib-1.3.1.tar.gz
 if [ ! -L zlib ]; then
     ln -s zlib-1.3.1 zlib
     cd onvif_simple_server/extras
@@ -55,14 +60,14 @@ fi
 if [ ! -f json-c-0.18.tar.gz ]; then
     wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.18.tar.gz
 fi
-tar zxvf ./json-c-0.18.tar.gz
+tar zxf ./json-c-0.18.tar.gz
 if [ ! -L json-c ]; then
     ln -s json-c-0.18 json-c
-    mkdir -p json-c/build
     cd onvif_simple_server/extras
     ln -s ../../json-c-0.18 json-c
     cd ../..
 fi
+mkdir -p json-c/build
 
 cd onvif_simple_server
 


### PR DESCRIPTION
## Summary

- **devcontainer**: add `qemu-user-static` (required for ARM qemu tests added in #1072) and `pkg-config` (required by mdnsd `configure` script — without it, `PKG_CHECK_EXISTS` fails with a syntax error)
- **gitignore**: add `src/libwolf_*/` (downloaded WolfSSL/WolfMQTT source tarballs) and `scripts/yi-hack-Allwinner-v2/` (directory artifact created by `pack_fw.sh`)
- **onvif_simple_server init**: fix several bugs that caused silent failures during `./scripts/compile.sh`:
  - Add `set -e` so the script aborts on first error instead of continuing silently
  - Fix mbedtls version mismatch: was trying to extract `v3.4.0.tar.gz` but only `v3.6.5.tar.gz` is present; introduce `MBEDTLS_DIR` variable
  - Fix wolfssl symlink: was linking to `v5.8.2-stable` but the tarball extracts to `wolfssl-5.8.2-stable`; introduce `WOLFSSL_DIR` variable
  - Add GitHub mirror as fallback URL for zlib (zlib.net can be unreachable)
  - Always create `json-c/build/` directory (was only created on first run, breaking subsequent runs)
  - Use quiet `tar zxf` instead of verbose `tar zxvf` for cleaner output

## Test plan

- [ ] Rebuild devcontainer from scratch and verify `qemu-arm-static` and `pkg-config` are available
- [ ] Run `./scripts/compile.sh` from a clean clone — should complete without errors on all modules including `onvif_simple_server` and `mdnsd`
- [ ] Run `./scripts/compile.sh` a second time (re-run) — should also complete cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)