### PR TITLE
pack_fw: append git short hash to version for local builds

### DIFF
--- a/scripts/pack_fw.sh
+++ b/scripts/pack_fw.sh
@@ -93,12 +93,21 @@ BUILD_DIR=$BASE_DIR/build
 OUT_DIR=$BASE_DIR/out/$CAMERA_NAME
 VER=$(cat VERSION)
 
+# Append git short hash when building outside a tagged release,
+# so local builds are distinguishable from official releases.
+GIT_TAG=$(git -C "$BASE_DIR" tag --points-at HEAD 2>/dev/null | grep -Fx "$VER" | head -1)
+if [ -z "$GIT_TAG" ]; then
+    GIT_HASH=$(git -C "$BASE_DIR" rev-parse --short HEAD 2>/dev/null || echo "custom")
+    VER="${VER}-${GIT_HASH}"
+fi
+
 echo ""
 echo "------------------------------------------------------------------------"
 echo " YI-HACK - FIRMWARE PACKER"
 echo "------------------------------------------------------------------------"
 printf " camera_name      : %s\n" $CAMERA_NAME
 printf " camera_id        : %s\n" $CAMERA_ID
+printf " version          : %s\n" $VER
 printf "                      \n"
 printf " sysroot_dir      : %s\n" $SYSROOT_DIR
 printf " static_dir       : %s\n" $STATIC_DIR
@@ -136,8 +145,8 @@ echo -n ">>> Adding defaults... "
 echo "done!"
 
 # insert the version file
-echo -n ">>> Copying the version file... "
-cp $BASE_DIR/VERSION $TMP_DIR/yi-hack/version
+echo -n ">>> Writing the version file... "
+echo "$VER" > $TMP_DIR/yi-hack/version
 echo "done!"
 
 # insert the model suffix file


### PR DESCRIPTION
## Problem

When building the firmware locally, the generated package uses the same version string as the official release (e.g. `0.3.5`). This causes two issues:

1. **Indistinguishable builds**: there is no way to tell from the camera's web UI whether it is running an official release or a custom local build.
2. **False «up to date» in the web updater**: `fw_upgrade.sh` compares the installed version against the latest GitHub release tag. If a local build happens to have the same version string, the upgrade button reports *«No new firmware available»* even though the binaries may differ.

## Solution

In `pack_fw.sh`, check whether the current git `HEAD` has a tag that exactly matches the content of `VERSION`. If it does (i.e. this is an official tagged release), the version string is left unchanged. If it does not (any local or development build), the git short hash is appended:

```
0.3.5          ← official release (HEAD is tagged "0.3.5")
0.3.5-4486a72  ← local build (HEAD has no matching tag)
```

The resolved version is also printed in the packer header for visibility.

## Impact on official releases

None. The logic is a no-op whenever `pack_fw.sh` is run on a commit that carries a git tag matching `VERSION`, which is exactly the workflow used to produce official releases.

## Impact on the web updater

A local build (e.g. `0.3.5-4486a72`) will never match an official tag, so `fw_upgrade.sh` will always offer the option to download and install the latest official release — which is the desired behaviour for developers testing custom builds.

## Test plan

- [x] Run `pack_fw.sh` on a non-tagged commit → output filename and `/tmp/sd/yi-hack/version` contain the short hash suffix
- [x] Simulate a tagged commit (`git tag 0.3.5 HEAD`) → version stays as `0.3.5` with no suffix
- [x] Verify `pack_fw.all.sh` is unaffected (it delegates to `pack_fw.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)