### PR TITLE
[codex] Fix rotate command when loading camera config

### DIFF
--- a/src/www/httpd/cgi-bin/load.sh
+++ b/src/www/httpd/cgi-bin/load.sh
@@ -126,7 +126,7 @@ fi
 if [[ $(get_config ROTATE) == "no" ]] ; then
     ipc_cmd -r off
 else
-    ipc_cmd -r o
+    ipc_cmd -r on
 fi
 
 if [[ $(get_config CRUISE) == "off" ]] ; then


### PR DESCRIPTION
## Summary

Fix the rotate-on command replayed by `load.sh` after loading a camera config.

`ROTATE=yes` currently takes the rotate-on branch, but the command is sent as:

```sh
ipc_cmd -r o
```

This changes it to:

```sh
ipc_cmd -r on
```

## Context

The original PR also attempted to persist Camera Settings directly from `camera_settings.sh`. Per maintainer feedback, persistence is already handled by `mqttv4` from the dispatch queue, so that change has been removed and this PR is now limited to the typo fix.

## Validation

- `sh -n src/www/httpd/cgi-bin/load.sh`
- `bash -n src/www/httpd/cgi-bin/load.sh`

## Not Tested

- Full firmware image build
