### PR TITLE
Rtsp improvements: memory usage and frame corruption

### DIFF
--- a/src/rRTSPServer/include/AudioFramedMemorySource.hh
+++ b/src/rRTSPServer/include/AudioFramedMemorySource.hh
@@ -67,6 +67,9 @@ private:
     unsigned fuSecsPerFrame;
     char fConfigStr[5];
     Boolean fHaveStartedReading;
+    bool fHaveAnchor;
+    struct timeval fAnchorWall;
+    uint32_t fAnchorFt;
 };
 
 #endif

--- a/src/rRTSPServer/include/VideoFramedMemorySource.hh
+++ b/src/rRTSPServer/include/VideoFramedMemorySource.hh
@@ -67,6 +67,9 @@ private:
     Boolean fHaveStartedReading;
     Boolean fHaveLastCounter;
     u_int32_t fLastCounter;
+    bool fHaveAnchor;
+    struct timeval fAnchorWall;
+    uint32_t fAnchorFt;
 };
 
 #endif

--- a/src/rRTSPServer/include/VideoFramedMemorySource.hh
+++ b/src/rRTSPServer/include/VideoFramedMemorySource.hh
@@ -65,6 +65,8 @@ private:
     Boolean fLimitNumBytesToStream;
     u_int64_t fNumBytesToStream; // used iff "fLimitNumBytesToStream" is True
     Boolean fHaveStartedReading;
+    Boolean fHaveLastCounter;
+    u_int32_t fLastCounter;
 };
 
 #endif

--- a/src/rRTSPServer/include/rRTSPServer.h
+++ b/src/rRTSPServer/include/rRTSPServer.h
@@ -27,6 +27,7 @@
 
 #include <queue>
 #include <vector>
+#include <atomic>
 
 #include <sys/types.h>
 
@@ -240,8 +241,8 @@ struct __attribute__((__packed__)) frame_header_28 {
 };
 
 struct stream_type_s {
-    int codec_low;
-    int codec_high;
+    std::atomic<int> codec_low;
+    std::atomic<int> codec_high;
     int sps_type_low;
     int sps_type_high;
     int vps_type_low;

--- a/src/rRTSPServer/include/rRTSPServer.h
+++ b/src/rRTSPServer/include/rRTSPServer.h
@@ -30,6 +30,7 @@
 #include <atomic>
 
 #include <sys/types.h>
+#include <sys/time.h>
 
 #define BUFFER_FILE "/dev/shm/fshare_frame_buf"
 #define BUFFER_SHM "fshare_frame_buf"
@@ -250,5 +251,6 @@ struct stream_type_s {
 };
 
 long long current_timestamp();
+void frametime_to_presentation(uint32_t frame_time, struct timeval *pt);
 
 #endif

--- a/src/rRTSPServer/include/rRTSPServer.h
+++ b/src/rRTSPServer/include/rRTSPServer.h
@@ -251,6 +251,7 @@ struct stream_type_s {
 };
 
 long long current_timestamp();
-void frametime_to_presentation(uint32_t frame_time, struct timeval *pt);
+void frametime_to_presentation(uint32_t frame_time, struct timeval *pt,
+                               bool *have_anchor, struct timeval *anchor_wall, uint32_t *anchor_ft);
 
 #endif

--- a/src/rRTSPServer/src/AudioFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/AudioFramedMemorySource.cpp
@@ -62,7 +62,8 @@ AudioFramedMemorySource::AudioFramedMemorySource(UsageEnvironment& env,
                                                         unsigned char numChannels,
                                                         Boolean useTimeForPres)
     : FramedSource(env), fQBuffer(qBuffer), fProfile(1), fSamplingFrequency(samplingFrequency),
-      fNumChannels(numChannels), fUseTimeForPres(useTimeForPres), fHaveStartedReading(False) {
+      fNumChannels(numChannels), fUseTimeForPres(useTimeForPres), fHaveStartedReading(False),
+      fHaveAnchor(false), fAnchorFt(0) {
 
     u_int8_t samplingFrequencyIndex;
     int i;
@@ -191,7 +192,7 @@ void AudioFramedMemorySource::doGetNextFrame() {
     }
 
     if (!fUseTimeForPres) {
-        frametime_to_presentation(frame_time, &fPresentationTime);
+        frametime_to_presentation(frame_time, &fPresentationTime, &fHaveAnchor, &fAnchorWall, &fAnchorFt);
     } else {
         // Use system clock to set presentation time
         gettimeofday(&fPresentationTime, NULL);

--- a/src/rRTSPServer/src/AudioFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/AudioFramedMemorySource.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <queue>
 #include <vector>
+#include <utility>
 
 #include <pthread.h>
 
@@ -139,6 +140,7 @@ void AudioFramedMemorySource::doGetNextFrame() {
 
     if (debug & 8) fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() start - fMaxSize %d\n", current_timestamp(), fMaxSize);
 
+    output_frame f;
     while (!frameFound) {
         pthread_mutex_lock(&(fQBuffer->mutex));
         if (fQBuffer->frame_queue.size() == 0) {
@@ -150,49 +152,42 @@ void AudioFramedMemorySource::doGetNextFrame() {
             nextTask() = envir().taskScheduler().scheduleDelayedTask(2000,
                                  (TaskFunc*)FramedSource::afterGetting, this);
             return;
-        } else if (fQBuffer->frame_queue.front().frame.size() == 0) {
-            // Drop the bad (empty) frame instead of spin-waiting on it
+        } else if (fQBuffer->frame_queue.front().frame.size() < (unsigned)(HEADER_SIZE + 1)) {
+            // Too small, drop it
             fQBuffer->frame_queue.pop();
             pthread_mutex_unlock(&(fQBuffer->mutex));
-            fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() error - NULL ptr\n", current_timestamp());
+            fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() error - bad frame (too small)\n", current_timestamp());
         } else if (check_sync_word(fQBuffer->frame_queue.front().frame.data()) != 1) {
-            if (fQBuffer->frame_queue.size() > 0) {
-                fQBuffer->frame_queue.pop();
-            }
+            fQBuffer->frame_queue.pop();
             pthread_mutex_unlock(&(fQBuffer->mutex));
             fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() error - wrong frame header\n", current_timestamp());
         } else {
+            // Deliver this frame: take ownership and release the lock before the copy below
+            f = std::move(fQBuffer->frame_queue.front());
+            fQBuffer->frame_queue.pop();
+            pthread_mutex_unlock(&(fQBuffer->mutex));
             frameFound = true;
         }
     }
 
-    if (debug & 8) fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() size of queue is %d\n", current_timestamp(), fQBuffer->frame_queue.size());
-
-    // Frame found, send it
-    unsigned char *ptr;
-    int size = fQBuffer->frame_queue.front().frame.size();
-    uint32_t frame_time = fQBuffer->frame_queue.front().time;
-    ptr = fQBuffer->frame_queue.front().frame.data();
-    ptr += HEADER_SIZE;
+    // Frame found (owned by 'f', lock already released)
+    int size = (int) f.frame.size();
+    uint32_t frame_time = f.time;
+    unsigned char *ptr = f.frame.data() + HEADER_SIZE;
     size -= HEADER_SIZE;
 
     if ((unsigned) size <= fMaxSize) {
-        // The size of the frame is smaller than the available buffer
+        // The frame fits in the available buffer
         fFrameSize = size;
         if (debug & 8) fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() whole frame - fFrameSize %d - fMaxSize %d - counter %d - time %u\n",
-                current_timestamp(), fFrameSize, fMaxSize, fQBuffer->frame_queue.front().counter, frame_time);
+                current_timestamp(), fFrameSize, fMaxSize, f.counter, frame_time);
         std::memcpy(fTo, ptr, size);
-        fQBuffer->frame_queue.pop();
-        pthread_mutex_unlock(&(fQBuffer->mutex));
         fNumTruncatedBytes = 0;
     } else {
-        // The size of the frame is greater than the available buffer
-        fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() error - the size of the frame is greater than the available buffer %d/%d\n", current_timestamp(), fFrameSize, fMaxSize);
+        // The frame is larger than the available buffer: drop it
         fFrameSize = 0;
-        fQBuffer->frame_queue.pop();
-        pthread_mutex_unlock(&(fQBuffer->mutex));
         fNumTruncatedBytes = 0;
-        fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() frame lost\n", current_timestamp());
+        fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() error - frame larger than buffer %d/%d - frame lost\n", current_timestamp(), size, fMaxSize);
     }
 
     if (!fUseTimeForPres) {

--- a/src/rRTSPServer/src/AudioFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/AudioFramedMemorySource.cpp
@@ -116,16 +116,19 @@ void AudioFramedMemorySource::doGetNextFrameEx() {
 
 void AudioFramedMemorySource::doGetNextFrame() {
     Boolean frameFound = false;
-    Boolean isFirstReading = !fHaveStartedReading;
+
     if (!fHaveStartedReading) {
         if (debug & 8) fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() 1st start\n", current_timestamp());
+        // Do NOT block the (single-threaded) event loop
         pthread_mutex_lock(&(fQBuffer->mutex));
-        // Yes, I know that I should not block the event loop
-        while (fQBuffer->frame_queue.size() < 5) {
+        unsigned qSize = fQBuffer->frame_queue.size();
+        if (qSize < 5) {
             pthread_mutex_unlock(&(fQBuffer->mutex));
-            usleep(2000);
-            pthread_mutex_lock(&(fQBuffer->mutex));
+            nextTask() = envir().taskScheduler().scheduleDelayedTask(2000,
+                                 doGetNextFrameTask, this);
+            return;
         }
+        // Keep only the most recent frames to reduce initial latency.
         while (fQBuffer->frame_queue.size() > 5) fQBuffer->frame_queue.pop();
         pthread_mutex_unlock(&(fQBuffer->mutex));
         fHaveStartedReading = True;
@@ -147,9 +150,10 @@ void AudioFramedMemorySource::doGetNextFrame() {
                                  (TaskFunc*)FramedSource::afterGetting, this);
             return;
         } else if (fQBuffer->frame_queue.front().frame.size() == 0) {
+            // Drop the bad (empty) frame instead of spin-waiting on it
+            fQBuffer->frame_queue.pop();
             pthread_mutex_unlock(&(fQBuffer->mutex));
             fprintf(stderr, "%lld: AudioFramedMemorySource - doGetNextFrame() error - NULL ptr\n", current_timestamp());
-            usleep(2000);
         } else if (check_sync_word(fQBuffer->frame_queue.front().frame.data()) != 1) {
             if (fQBuffer->frame_queue.size() > 0) {
                 fQBuffer->frame_queue.pop();

--- a/src/rRTSPServer/src/AudioFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/AudioFramedMemorySource.cpp
@@ -102,6 +102,7 @@ int AudioFramedMemorySource::check_sync_word(unsigned char *str)
 }
 
 void AudioFramedMemorySource::doStopGettingFrames() {
+    envir().taskScheduler().unscheduleDelayedTask(nextTask());
     fHaveStartedReading = False;
 }
 

--- a/src/rRTSPServer/src/AudioFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/AudioFramedMemorySource.cpp
@@ -196,8 +196,7 @@ void AudioFramedMemorySource::doGetNextFrame() {
     }
 
     if (!fUseTimeForPres) {
-        fPresentationTime.tv_usec = (frame_time % 1000) * 1000;
-        fPresentationTime.tv_sec = frame_time / 1000;
+        frametime_to_presentation(frame_time, &fPresentationTime);
     } else {
         // Use system clock to set presentation time
         gettimeofday(&fPresentationTime, NULL);

--- a/src/rRTSPServer/src/VideoFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/VideoFramedMemorySource.cpp
@@ -208,8 +208,7 @@ void VideoFramedMemorySource::doGetNextFrame() {
     }
 
     if (!fUseTimeForPres) {
-        fPresentationTime.tv_usec = (frame_time % 1000) * 1000;
-        fPresentationTime.tv_sec = frame_time / 1000;
+        frametime_to_presentation(frame_time, &fPresentationTime);
     } else {
         // Set the 'presentation time':
         // Use system clock to set presentation time

--- a/src/rRTSPServer/src/VideoFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/VideoFramedMemorySource.cpp
@@ -70,7 +70,7 @@ VideoFramedMemorySource::VideoFramedMemorySource(UsageEnvironment& env,
     : FramedSource(env), fHNumber(hNumber), fQBuffer(qBuffer),
       fCurIndex(0), fUseTimeForPres(useTimeForPres), fPlayTimePerFrame(playTimePerFrame), fLastPlayTime(0),
       fLimitNumBytesToStream(False), fNumBytesToStream(0), fHaveStartedReading(False),
-      fHaveLastCounter(False), fLastCounter(0) {
+      fHaveLastCounter(False), fLastCounter(0), fHaveAnchor(false), fAnchorFt(0) {
 
     if (debug & 4) fprintf(stderr, "%lld: VideoFramedMemorySource - fPlayTimePerFrame %u\n", current_timestamp(), fPlayTimePerFrame);
 }
@@ -203,7 +203,7 @@ void VideoFramedMemorySource::doGetNextFrame() {
     }
 
     if (!fUseTimeForPres) {
-        frametime_to_presentation(frame_time, &fPresentationTime);
+        frametime_to_presentation(frame_time, &fPresentationTime, &fHaveAnchor, &fAnchorWall, &fAnchorFt);
     } else {
         // Set the 'presentation time':
         // Use system clock to set presentation time

--- a/src/rRTSPServer/src/VideoFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/VideoFramedMemorySource.cpp
@@ -100,14 +100,15 @@ void VideoFramedMemorySource::doGetNextFrame() {
 
     if (!fHaveStartedReading) {
         if (debug & 4) fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() 1st start\n", current_timestamp());
+        // Do NOT block the (single-threaded) event loop
         pthread_mutex_lock(&(fQBuffer->mutex));
-        // Yes, I know that I should not block the event loop
-        while (fQBuffer->frame_queue.size() < 5) {
-            pthread_mutex_unlock(&(fQBuffer->mutex));
-            usleep(2000);
-            pthread_mutex_lock(&(fQBuffer->mutex));
-        }
+        unsigned qSize = fQBuffer->frame_queue.size();
         pthread_mutex_unlock(&(fQBuffer->mutex));
+        if (qSize < 5) {
+            nextTask() = envir().taskScheduler().scheduleDelayedTask(2000,
+                                 doGetNextFrameTask, this);
+            return;
+        }
         fHaveStartedReading = True;
         // Force a resync to a keyframe/parameter-set before delivering the first frame
         fHaveLastCounter = False;
@@ -138,9 +139,10 @@ void VideoFramedMemorySource::doGetNextFrame() {
                                  (TaskFunc*)FramedSource::afterGetting, this);
             return;
         } else if (fQBuffer->frame_queue.front().frame.size() == 0) {
+            // Drop the bad (empty) frame instead of spin-waiting on it
+            fQBuffer->frame_queue.pop();
             pthread_mutex_unlock(&(fQBuffer->mutex));
             fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() error - NULL ptr\n", current_timestamp());
-            usleep(2000);
         } else if (memcmp(NALU_HEADER, fQBuffer->frame_queue.front().frame.data(), sizeof(NALU_HEADER)) != 0) {
             // Maybe the buffer is too small, align read index with write index
             if (fQBuffer->frame_queue.size() > 0) {

--- a/src/rRTSPServer/src/VideoFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/VideoFramedMemorySource.cpp
@@ -32,6 +32,22 @@ unsigned char NALU_HEADER[] = { 0x00, 0x00, 0x00, 0x01 };
 
 extern int debug;
 
+// Return True if the NAL unit is a decoder sync point
+static Boolean isSyncFrame(int hNumber, unsigned char const* frame, unsigned size) {
+    if (size < 5) return False;
+    unsigned char nalHdr = frame[4];
+    if (hNumber == 264) {
+        unsigned nut = nalHdr & 0x1F;
+        // 5 = IDR slice, 7 = SPS, 8 = PPS
+        return (nut == 5 || nut == 7 || nut == 8) ? True : False;
+    } else if (hNumber == 265) {
+        unsigned nut = (nalHdr >> 1) & 0x3F;
+        // 16..23 = IRAP (BLA/IDR/CRA), 32 = VPS, 33 = SPS, 34 = PPS
+        return ((nut >= 16 && nut <= 23) || nut == 32 || nut == 33 || nut == 34) ? True : False;
+    }
+    return True;
+}
+
 ////////// VideoFramedMemorySource //////////
 
 VideoFramedMemorySource*
@@ -52,7 +68,8 @@ VideoFramedMemorySource::VideoFramedMemorySource(UsageEnvironment& env,
                                                         unsigned playTimePerFrame)
     : FramedSource(env), fHNumber(hNumber), fQBuffer(qBuffer),
       fCurIndex(0), fUseTimeForPres(useTimeForPres), fPlayTimePerFrame(playTimePerFrame), fLastPlayTime(0),
-      fLimitNumBytesToStream(False), fNumBytesToStream(0), fHaveStartedReading(False) {
+      fLimitNumBytesToStream(False), fNumBytesToStream(0), fHaveStartedReading(False),
+      fHaveLastCounter(False), fLastCounter(0) {
 
     if (debug & 4) fprintf(stderr, "%lld: VideoFramedMemorySource - fPlayTimePerFrame %u\n", current_timestamp(), fPlayTimePerFrame);
 }
@@ -90,9 +107,10 @@ void VideoFramedMemorySource::doGetNextFrame() {
             usleep(2000);
             pthread_mutex_lock(&(fQBuffer->mutex));
         }
-        while (fQBuffer->frame_queue.size() > 5) fQBuffer->frame_queue.pop();
         pthread_mutex_unlock(&(fQBuffer->mutex));
         fHaveStartedReading = True;
+        // Force a resync to a keyframe/parameter-set before delivering the first frame
+        fHaveLastCounter = False;
     }
 
     if (fLimitNumBytesToStream && fNumBytesToStream == 0) {
@@ -131,7 +149,22 @@ void VideoFramedMemorySource::doGetNextFrame() {
             pthread_mutex_unlock(&(fQBuffer->mutex));
             fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() error - wrong frame header\n", current_timestamp());
         } else {
-            frameFound = true;
+            // Keyframe-aware resync: after a discontinuity (frames dropped on
+            // queue overflow, or a fresh (re)start) resume only at a decoder
+            // sync point
+            u_int32_t counter = (u_int32_t) fQBuffer->frame_queue.front().counter;
+            Boolean discontinuity = (!fHaveLastCounter) ||
+                                    (counter != ((fLastCounter + 1) & 0xFFFF));
+            if (discontinuity &&
+                !isSyncFrame(fHNumber,
+                             fQBuffer->frame_queue.front().frame.data(),
+                             fQBuffer->frame_queue.front().frame.size())) {
+                fQBuffer->frame_queue.pop();
+                pthread_mutex_unlock(&(fQBuffer->mutex));
+                if (debug & 4) fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() resync - skipping orphan frame\n", current_timestamp());
+            } else {
+                frameFound = true;
+            }
         }
     }
 
@@ -142,6 +175,7 @@ void VideoFramedMemorySource::doGetNextFrame() {
     unsigned char nal;
     int size = fQBuffer->frame_queue.front().frame.size();
     uint32_t frame_time = fQBuffer->frame_queue.front().time;
+    u_int32_t frame_counter = (u_int32_t) fQBuffer->frame_queue.front().counter;
     ptr = fQBuffer->frame_queue.front().frame.data();
     // Remove nalu header before sending the frame to FramedSource
     ptr += 4 * sizeof(unsigned char);
@@ -157,6 +191,9 @@ void VideoFramedMemorySource::doGetNextFrame() {
         fQBuffer->frame_queue.pop();
         pthread_mutex_unlock(&(fQBuffer->mutex));
         fNumTruncatedBytes = 0;
+        // Frame delivered: remember its sequence counter
+        fLastCounter = frame_counter;
+        fHaveLastCounter = True;
     } else {
         // The size of the frame is greater than the available buffer
         fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() error - the size of the frame is greater than the available buffer %d/%d\n", current_timestamp(), fFrameSize, fMaxSize);

--- a/src/rRTSPServer/src/VideoFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/VideoFramedMemorySource.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <queue>
 #include <vector>
+#include <utility>
 
 unsigned char NALU_HEADER[] = { 0x00, 0x00, 0x00, 0x01 };
 
@@ -128,6 +129,7 @@ void VideoFramedMemorySource::doGetNextFrame() {
 
     if (debug & 4) fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() start - fMaxSize %d - fLimitNumBytesToStream %d\n", current_timestamp(), fMaxSize, fLimitNumBytesToStream);
 
+    output_frame f;
     while (!frameFound) {
         pthread_mutex_lock(&(fQBuffer->mutex));
         if (fQBuffer->frame_queue.size() == 0) {
@@ -139,11 +141,11 @@ void VideoFramedMemorySource::doGetNextFrame() {
             nextTask() = envir().taskScheduler().scheduleDelayedTask(2000,
                                  (TaskFunc*)FramedSource::afterGetting, this);
             return;
-        } else if (fQBuffer->frame_queue.front().frame.size() == 0) {
-            // Drop the bad (empty) frame instead of spin-waiting on it
+        } else if (fQBuffer->frame_queue.front().frame.size() < 5) {
+            // Too small, drop it
             fQBuffer->frame_queue.pop();
             pthread_mutex_unlock(&(fQBuffer->mutex));
-            fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() error - NULL ptr\n", current_timestamp());
+            fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() error - bad frame (too small)\n", current_timestamp());
         } else if (memcmp(NALU_HEADER, fQBuffer->frame_queue.front().frame.data(), sizeof(NALU_HEADER)) != 0) {
             // Maybe the buffer is too small, align read index with write index
             if (fQBuffer->frame_queue.size() > 0) {
@@ -166,45 +168,38 @@ void VideoFramedMemorySource::doGetNextFrame() {
                 pthread_mutex_unlock(&(fQBuffer->mutex));
                 if (debug & 4) fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() resync - skipping orphan frame\n", current_timestamp());
             } else {
+                // Deliver this frame: take ownership and release the lock before the copy below
+                f = std::move(fQBuffer->frame_queue.front());
+                fQBuffer->frame_queue.pop();
+                pthread_mutex_unlock(&(fQBuffer->mutex));
                 frameFound = true;
             }
         }
     }
 
-    if (debug & 4) fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() size of queue is %d\n", current_timestamp(), fQBuffer->frame_queue.size());
-
-    // Frame found, send it
-    unsigned char *ptr;
-    unsigned char nal;
-    int size = fQBuffer->frame_queue.front().frame.size();
-    uint32_t frame_time = fQBuffer->frame_queue.front().time;
-    u_int32_t frame_counter = (u_int32_t) fQBuffer->frame_queue.front().counter;
-    ptr = fQBuffer->frame_queue.front().frame.data();
-    // Remove nalu header before sending the frame to FramedSource
-    ptr += 4 * sizeof(unsigned char);
-    size -= 4 * sizeof(unsigned char);
-    nal = ptr[0];
+    // Frame found (owned by 'f', lock already released)
+    int size = (int) f.frame.size();
+    uint32_t frame_time = f.time;
+    u_int32_t frame_counter = (u_int32_t) f.counter;
+    unsigned char *ptr = f.frame.data() + 4;
+    size -= 4;
+    unsigned char nal = ptr[0];
 
     if ((unsigned) size <= fFrameSize) {
-        // The size of the frame is smaller than the available buffer
+        // The frame fits in the available buffer
         fFrameSize = size;
         if (debug & 4) fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() whole frame - fFrameSize %d - fMaxSize %d - counter %d - time %u\n",
-                current_timestamp(), fFrameSize, fMaxSize, fQBuffer->frame_queue.front().counter, frame_time);
+                current_timestamp(), fFrameSize, fMaxSize, frame_counter, frame_time);
         std::memcpy(fTo, ptr, size);
-        fQBuffer->frame_queue.pop();
-        pthread_mutex_unlock(&(fQBuffer->mutex));
         fNumTruncatedBytes = 0;
         // Frame delivered: remember its sequence counter
         fLastCounter = frame_counter;
         fHaveLastCounter = True;
     } else {
-        // The size of the frame is greater than the available buffer
-        fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() error - the size of the frame is greater than the available buffer %d/%d\n", current_timestamp(), fFrameSize, fMaxSize);
+        // The frame is larger than the available buffer: drop it
         fFrameSize = 0;
-        fQBuffer->frame_queue.pop();
-        pthread_mutex_unlock(&(fQBuffer->mutex));
         fNumTruncatedBytes = 0;
-        fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() frame lost\n", current_timestamp());
+        fprintf(stderr, "%lld: VideoFramedMemorySource - doGetNextFrame() error - frame larger than buffer %d/%d - frame lost\n", current_timestamp(), size, fMaxSize);
     }
 
     if (!fUseTimeForPres) {

--- a/src/rRTSPServer/src/VideoFramedMemorySource.cpp
+++ b/src/rRTSPServer/src/VideoFramedMemorySource.cpp
@@ -83,6 +83,7 @@ void VideoFramedMemorySource::seekToByteRelative(int64_t offset, u_int64_t numBy
 }
 
 void VideoFramedMemorySource::doStopGettingFrames() {
+    envir().taskScheduler().unscheduleDelayedTask(nextTask());
     fHaveStartedReading = False;
 }
 

--- a/src/rRTSPServer/src/rRTSPServer.cpp
+++ b/src/rRTSPServer/src/rRTSPServer.cpp
@@ -249,32 +249,40 @@ long long current_timestamp() {
  * Map a camera frame timestamp (uint32 ms since boot, wraps ~every 49 days,
  * not wall-clock) to a real wall-clock presentation time suitable for RTP/RTCP.
  *
- * A single anchor (camera_ms <-> wall clock) is captured on the first call and
- * shared by every source. Each source then maps through the SAME affine
- * function, so the relative timing between audio and video is preserved exactly
- * (perfect A/V sync) while presentation times become real wall-clock (correct
- * RTCP sender reports). The uint32 subtraction handles the camera-clock wrap
- * transparently for any session shorter than ~49 days since the anchor.
+ * The anchor (camera_ms <-> wall clock) is held by the CALLER and is therefore
+ * PER-SOURCE: video and audio each keep their own anchor. This avoids coupling
+ * two independent (possibly different-based) camera clocks through one shared
+ * anchor, which could otherwise make one stream's frame precede the anchor and
+ * underflow the uint32 subtraction into a ~49-day-in-the-future timestamp
+ * (freezing that stream, and the client's A/V sync with it).
  *
- * Must be called only from the (single-threaded) live555 event loop, so the
- * function-local state needs no locking.
+ * We also (re)anchor whenever a frame precedes the current anchor (out-of-order
+ * or a clock reset), using a SIGNED delta, so a backwards timestamp re-syncs to
+ * "now" instead of jumping far into the future.
+ *
+ * Presentation times become real wall-clock (correct RTCP), and within a source
+ * the uint32 subtraction still handles the camera-clock wrap. A/V sync is
+ * preserved up to the (small) difference in per-stream pipeline latency.
+ *
+ * Must be called only from the (single-threaded) live555 event loop.
  */
-void frametime_to_presentation(uint32_t frame_time, struct timeval *pt) {
-    static bool anchored = false;
-    static struct timeval anchor_wall;
-    static uint32_t anchor_ft;
-
-    if (!anchored) {
-        gettimeofday(&anchor_wall, NULL);
-        anchor_ft = frame_time;
-        anchored = true;
-        *pt = anchor_wall;
+void frametime_to_presentation(uint32_t frame_time, struct timeval *pt,
+                               bool *have_anchor, struct timeval *anchor_wall, uint32_t *anchor_ft) {
+    // Re-anchor on the first frame, or if this frame precedes the anchor.
+    if (*have_anchor && (int32_t)(frame_time - *anchor_ft) < 0) {
+        *have_anchor = false;
+    }
+    if (!*have_anchor) {
+        gettimeofday(anchor_wall, NULL);
+        *anchor_ft = frame_time;
+        *have_anchor = true;
+        *pt = *anchor_wall;
         return;
     }
 
-    uint32_t delta_ms = frame_time - anchor_ft;   // modular: handles the wrap
-    uint64_t usec = (uint64_t) anchor_wall.tv_usec + (uint64_t)(delta_ms % 1000) * 1000;
-    pt->tv_sec  = anchor_wall.tv_sec + (time_t)(delta_ms / 1000) + (time_t)(usec / 1000000);
+    uint32_t delta_ms = frame_time - *anchor_ft;   // modular: handles the wrap
+    uint64_t usec = (uint64_t) anchor_wall->tv_usec + (uint64_t)(delta_ms % 1000) * 1000;
+    pt->tv_sec  = anchor_wall->tv_sec + (time_t)(delta_ms / 1000) + (time_t)(usec / 1000000);
     pt->tv_usec = (long)(usec % 1000000);
 }
 

--- a/src/rRTSPServer/src/rRTSPServer.cpp
+++ b/src/rRTSPServer/src/rRTSPServer.cpp
@@ -837,13 +837,18 @@ void *capture(void *ptr)
                         copy_src = input_buffer.read_index;
                     }
 
-                    output_frame of;
-                    of.frame.resize(frame_len);
-                    cb2s_memcpy(of.frame.data(), copy_src, frame_len);
-                    of.counter = frame_counter;
-                    of.time = frame_time;
-                    p_output_queue->frame_queue.push(std::move(of));
-                    while (p_output_queue->frame_queue.size() > MAX_QUEUE_SIZE) p_output_queue->frame_queue.pop();
+                    // Guard against a corrupt/short frame
+                    if (frame_len > 0) {
+                        output_frame of;
+                        of.frame.resize(frame_len);
+                        cb2s_memcpy(of.frame.data(), copy_src, frame_len);
+                        of.counter = frame_counter;
+                        of.time = frame_time;
+                        p_output_queue->frame_queue.push(std::move(of));
+                        while (p_output_queue->frame_queue.size() > MAX_QUEUE_SIZE) p_output_queue->frame_queue.pop();
+                    } else {
+                        fprintf(stderr, "%lld: h264/aac in - warning - invalid frame_len %d, frame dropped\n", current_timestamp(), frame_len);
+                    }
 
                     if (debug & 3) {
                         fprintf(stderr, "%lld: h264/aac in - frame_len: %d - frame_counter: %d - resolution: %d\n", current_timestamp(), frame_len, frame_counter, frame_type);

--- a/src/rRTSPServer/src/rRTSPServer.cpp
+++ b/src/rRTSPServer/src/rRTSPServer.cpp
@@ -614,7 +614,7 @@ void *capture(void *ptr)
                         stream_type.sps_type_low = 0x0000;
                     }
                     if ((debug & 1) && (stream_type.codec_low != CODEC_NONE)) fprintf(stderr, "%lld: h264 in - low - codec type is %d - sps type is %d\n",
-                            current_timestamp(), stream_type.codec_low, stream_type.sps_type_low);
+                            current_timestamp(), stream_type.codec_low.load(), stream_type.sps_type_low);
                 } else if ((stream_type.codec_high  == CODEC_NONE) && (fhs[i].type & 0x0400)) {
                     if (cb_memcmp(SPS4_1920X1080, buf_idx_cur, sizeof(SPS4_1920X1080)) == 0) {
                         stream_type.codec_high = CODEC_H264;
@@ -651,7 +651,7 @@ void *capture(void *ptr)
                         stream_type.sps_type_high = 0x0000;
                     }
                     if ((debug & 1) && (stream_type.codec_high != CODEC_NONE)) fprintf(stderr, "%lld: h264 in - high - codec type is %d - sps type is %d\n",
-                            current_timestamp(), stream_type.codec_high, stream_type.sps_type_high);
+                            current_timestamp(), stream_type.codec_high.load(), stream_type.sps_type_high);
                 }
             } else {
                 buf_idx_cur = cb_move(buf_idx_cur, frame_header_size);

--- a/src/rRTSPServer/src/rRTSPServer.cpp
+++ b/src/rRTSPServer/src/rRTSPServer.cpp
@@ -238,11 +238,44 @@ UsageEnvironment* env;
 Boolean reuseFirstSource = True;
 
 long long current_timestamp() {
-    struct timeval te; 
+    struct timeval te;
     gettimeofday(&te, NULL); // get current time
     long long milliseconds = te.tv_sec*1000LL + te.tv_usec/1000; // calculate milliseconds
 
     return milliseconds;
+}
+
+/*
+ * Map a camera frame timestamp (uint32 ms since boot, wraps ~every 49 days,
+ * not wall-clock) to a real wall-clock presentation time suitable for RTP/RTCP.
+ *
+ * A single anchor (camera_ms <-> wall clock) is captured on the first call and
+ * shared by every source. Each source then maps through the SAME affine
+ * function, so the relative timing between audio and video is preserved exactly
+ * (perfect A/V sync) while presentation times become real wall-clock (correct
+ * RTCP sender reports). The uint32 subtraction handles the camera-clock wrap
+ * transparently for any session shorter than ~49 days since the anchor.
+ *
+ * Must be called only from the (single-threaded) live555 event loop, so the
+ * function-local state needs no locking.
+ */
+void frametime_to_presentation(uint32_t frame_time, struct timeval *pt) {
+    static bool anchored = false;
+    static struct timeval anchor_wall;
+    static uint32_t anchor_ft;
+
+    if (!anchored) {
+        gettimeofday(&anchor_wall, NULL);
+        anchor_ft = frame_time;
+        anchored = true;
+        *pt = anchor_wall;
+        return;
+    }
+
+    uint32_t delta_ms = frame_time - anchor_ft;   // modular: handles the wrap
+    uint64_t usec = (uint64_t) anchor_wall.tv_usec + (uint64_t)(delta_ms % 1000) * 1000;
+    pt->tv_sec  = anchor_wall.tv_sec + (time_t)(delta_ms / 1000) + (time_t)(usec / 1000000);
+    pt->tv_usec = (long)(usec % 1000000);
 }
 
 /* Locate a string in the circular buffer */

--- a/src/rRTSPServer/src/rRTSPServer.cpp
+++ b/src/rRTSPServer/src/rRTSPServer.cpp
@@ -782,7 +782,7 @@ void *capture(void *ptr)
 
                 if (p_output_queue != NULL) {
                     if (debug & 3) fprintf(stderr, "%lld: h264/aac in - frame_len: %d - cb_current->size: %d\n", current_timestamp(), frame_len, p_output_queue->frame_queue.size());
-                    pthread_mutex_lock(&(p_output_queue->mutex));
+                    // Build the frame outside the lock
                     input_buffer.read_index = buf_idx_start;
                     unsigned char *copy_src = input_buffer.read_index;
 
@@ -874,11 +874,14 @@ void *capture(void *ptr)
                     if (frame_len > 0) {
                         output_frame of;
                         of.frame.resize(frame_len);
-                        cb2s_memcpy(of.frame.data(), copy_src, frame_len);
+                        cb2s_memcpy(of.frame.data(), copy_src, frame_len);   // copy outside the lock
                         of.counter = frame_counter;
                         of.time = frame_time;
+                        // Lock only for the queue push + overflow trim
+                        pthread_mutex_lock(&(p_output_queue->mutex));
                         p_output_queue->frame_queue.push(std::move(of));
                         while (p_output_queue->frame_queue.size() > MAX_QUEUE_SIZE) p_output_queue->frame_queue.pop();
+                        pthread_mutex_unlock(&(p_output_queue->mutex));
                     } else {
                         fprintf(stderr, "%lld: h264/aac in - warning - invalid frame_len %d, frame dropped\n", current_timestamp(), frame_len);
                     }
@@ -886,7 +889,6 @@ void *capture(void *ptr)
                     if (debug & 3) {
                         fprintf(stderr, "%lld: h264/aac in - frame_len: %d - frame_counter: %d - resolution: %d\n", current_timestamp(), frame_len, frame_counter, frame_type);
                     }
-                    pthread_mutex_unlock(&(p_output_queue->mutex));
                 }
             }
         }

--- a/src/rRTSPServer/src/rRTSPServer.cpp
+++ b/src/rRTSPServer/src/rRTSPServer.cpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <queue>
 #include <vector>
+#include <utility>
 
 #include <getopt.h>
 #include <pthread.h>
@@ -750,7 +751,7 @@ void *capture(void *ptr)
                     if (debug & 3) fprintf(stderr, "%lld: h264/aac in - frame_len: %d - cb_current->size: %d\n", current_timestamp(), frame_len, p_output_queue->frame_queue.size());
                     pthread_mutex_lock(&(p_output_queue->mutex));
                     input_buffer.read_index = buf_idx_start;
-                    unsigned char *tmp_out;
+                    unsigned char *copy_src = input_buffer.read_index;
 
                     if (sps_timing_info) {
                         // Overwrite SPS or VPS with one that contains timing info at 20 fps
@@ -758,113 +759,90 @@ void *capture(void *ptr)
                             if (frame_type == TYPE_LOW) {
                                 if (stream_type.sps_type_low & 0x0101) {
                                     frame_len = sizeof(SPS4_640X360_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_640X360_TI, frame_len);
+                                    copy_src = SPS4_640X360_TI;
                                 } else if (stream_type.sps_type_low & 0x0201) {
                                     frame_len = sizeof(SPS4_2_640X360_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_2_640X360_TI, frame_len);
+                                    copy_src = SPS4_2_640X360_TI;
                                 } else if (stream_type.sps_type_low & 0x0401) {
                                     frame_len = sizeof(SPS4_3_640X360_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_3_640X360_TI, frame_len);
+                                    copy_src = SPS4_3_640X360_TI;
                                 } else {
                                     // don't change frame_len
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, input_buffer.read_index, frame_len);
+                                    copy_src = input_buffer.read_index;
                                 }
                             } else if (frame_type == TYPE_HIGH) {
                                 if (stream_type.sps_type_high == 0x0102) {
                                     frame_len = sizeof(SPS4_1920X1080_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_1920X1080_TI, frame_len);
+                                    copy_src = SPS4_1920X1080_TI;
                                 } else if (stream_type.sps_type_high == 0x0202) {
                                     frame_len = sizeof(SPS4_2_1920X1080_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_2_1920X1080_TI, frame_len);
+                                    copy_src = SPS4_2_1920X1080_TI;
                                 } else if (stream_type.sps_type_high == 0x0402) {
                                     frame_len = sizeof(SPS4_3_1920X1080_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_3_1920X1080_TI, frame_len);
+                                    copy_src = SPS4_3_1920X1080_TI;
                                 } else if (stream_type.sps_type_high == 0x0103) {
                                     frame_len = sizeof(SPS4_2304X1296_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_2304X1296_TI, frame_len);
+                                    copy_src = SPS4_2304X1296_TI;
                                 } else if (stream_type.sps_type_high == 0x0203) {
                                     frame_len = sizeof(SPS4_2_2304X1296_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_2_2304X1296_TI, frame_len);
+                                    copy_src = SPS4_2_2304X1296_TI;
                                 } else if (stream_type.sps_type_high == 0x0403) {
                                     frame_len = sizeof(SPS4_3_2304X1296_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS4_3_2304X1296_TI, frame_len);
+                                    copy_src = SPS4_3_2304X1296_TI;
 /*                                } else if (stream_type.sps_type_high & 0x0802) {
                                     frame_len = sizeof(SPS5_1920X1080_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS5_1920X1080_TI, frame_len);
+                                    copy_src = SPS5_1920X1080_TI;
                                 } else if (stream_type.sps_type_high & 0x1002) {
                                     frame_len = sizeof(SPS5_2_1920X1080_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS5_2_1920X1080_TI, frame_len);
+                                    copy_src = SPS5_2_1920X1080_TI;
                                 } else if (stream_type.sps_type_high & 0x2002) {
                                     frame_len = sizeof(SPS5_3_2304X1296_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, SPS5_3_2304X1296_TI, frame_len); */
+                                    copy_src = SPS5_3_2304X1296_TI; */
                                 } else {
                                     // don't change frame_len
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, input_buffer.read_index, frame_len);
+                                    copy_src = input_buffer.read_index;
                                 }
                             } else {
                                 // don't change frame_len
-                                tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                cb2s_memcpy(tmp_out, input_buffer.read_index, frame_len);
+                                copy_src = input_buffer.read_index;
                             }
                         } else if (fhs[i].type & 0x0008) {
                             if (frame_type == TYPE_LOW) {
                                 // don't change frame_len
-                                tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                cb2s_memcpy(tmp_out, input_buffer.read_index, frame_len);
+                                copy_src = input_buffer.read_index;
                             } else if (frame_type == TYPE_HIGH) {
 /*                                if (stream_type.sps_type_high == 0x0802) {
                                     frame_len = sizeof(VPS5_1920X1080_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, VPS5_1920X1080_TI, frame_len);
+                                    copy_src = VPS5_1920X1080_TI;
                                 } else if (stream_type.sps_type_high == 0x1002) {
                                     frame_len = sizeof(VPS5_2_1920X1080_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, VPS5_2_1920_1080_TI, frame_len);
+                                    copy_src = VPS5_2_1920_1080_TI;
                                 } else if (stream_type.sps_type_high == 0x2002) {
                                     frame_len = sizeof(VPS5_3_2304X1296_TI);
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, VPS5_3_2304X1296_TI, frame_len);
+                                    copy_src = VPS5_3_2304X1296_TI;
                                 } else { */
                                     // don't change frame_len
-                                    tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                    cb2s_memcpy(tmp_out, input_buffer.read_index, frame_len);
+                                    copy_src = input_buffer.read_index;
 /*                                } */
                             } else {
                                 // don't change frame_len
-                                tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                                cb2s_memcpy(tmp_out, input_buffer.read_index, frame_len);
+                                copy_src = input_buffer.read_index;
                             }
                         } else {
                             // don't change frame_len
-                            tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                            cb2s_memcpy(tmp_out, input_buffer.read_index, frame_len);
+                            copy_src = input_buffer.read_index;
                         }
 
                     } else {
-                        tmp_out = (unsigned char *) malloc(frame_len * sizeof(unsigned char));
-                        cb2s_memcpy(tmp_out, input_buffer.read_index, frame_len);
+                        copy_src = input_buffer.read_index;
                     }
 
                     output_frame of;
-                    of.frame = {tmp_out, tmp_out + frame_len};
+                    of.frame.resize(frame_len);
+                    cb2s_memcpy(of.frame.data(), copy_src, frame_len);
                     of.counter = frame_counter;
                     of.time = frame_time;
-                    p_output_queue->frame_queue.push(of);
-                    free(tmp_out);
+                    p_output_queue->frame_queue.push(std::move(of));
                     while (p_output_queue->frame_queue.size() > MAX_QUEUE_SIZE) p_output_queue->frame_queue.pop();
 
                     if (debug & 3) {


### PR DESCRIPTION
Sync to IDR in case if frame drop
Remove potential block in event loop
Decrease memory (malloc) usage
unscheduleDelayedTask
Guard against a corrupt/short frame
Fix data race on stream_type
Improve presentation time
Improve mutex usage
Anchor per source 